### PR TITLE
PackageId Changed

### DIFF
--- a/demo/src/BlazorChartist/BlazorChartist.csproj
+++ b/demo/src/BlazorChartist/BlazorChartist.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
-    <PackageId>Demo.BlazorChartist</PackageId>
+    <PackageId>BlazorChartist</PackageId>
     <Description>Demonstration of a Blazor components package. Not intended for actual use.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
PackageId contained: <PackageId>Demo.BlazorChartist</PackageId>
Should be:
<PackageId>BlazorChartist</PackageId>
Otherwise the chartist js and css cannot be found